### PR TITLE
Write logs to stderr if used in non-Rails application

### DIFF
--- a/lib/takosan.rb
+++ b/lib/takosan.rb
@@ -36,6 +36,11 @@ module Takosan
   end
 
   def logger
-    @@_logger ||= Rails.logger
+    @@_logger ||=
+      if defined?(Rails.logger)
+        Rails.logger
+      else
+        Logger.new($stderr)
+      end
   end
 end


### PR DESCRIPTION
`Rails.logger` does not exist in my use case.
